### PR TITLE
[ OT221-68 ] Add Activity detail page

### DIFF
--- a/src/pages/activityDetail/ActivityDetailPage.js
+++ b/src/pages/activityDetail/ActivityDetailPage.js
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Loader } from '../../components/Loader';
+import Alert from '../../services/AlertService';
+import { getPublic } from '../../services/apiServices';
+
+/**
+ * Fake data. Please @comment this object when
+ * perform real backend comunication
+ */
+const activity = {
+  name: 'Reunión semanal',
+  image: 'https://adenuniversity.us/files/sites/3/2018/11/shutterstock_633351611.png',
+  content:'There are many variations of passages of Lorem Ipsum available,  but the majority have suffered alteration in some form, by injected humour, or randomised words which dont look even slightly believable.If you are going to use a passage of Lorem Ipsum, you need to be sure there isnt anything embarrassing hidden in the middle of text. All the Lorem Ipsum generatorson the Internet tend to repeat predefined chunks as necessary, making this the firsttrue generator on the Internet. It uses a dictionary of over 200 Latin words, combined with a handful of model sentence structures, to generate Lorem Ipsum which looks reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected humour, or non-characteristic words etc.'
+}
+
+const ActivityDetailPage = () => {
+
+  /**
+   * Please @uncomment the code below to perform the
+   * comunication with the endpoint. Please provide 
+   * an activity @id via url param. Ex: activity/1.
+   * Use this component inside a @Router environment to
+   * get access to react-router hooks
+   */
+
+  // const [activity, setActivity] = useState(null);
+  // const navigate = useNavigate();
+  // const { id } = useParams();
+
+  // // It performs the request, if the object data it 
+  // // contains the err property, it fires an alert with
+  // // the error. After user press OK in the alert pop up
+  // // it navigates to the previous page
+
+  // // If err property is not present, it set the activity
+  // // state
+  // useEffect(() => {
+  //   getPublic(`http://localhost:3001/auth/testendpoint/${ id }`)
+  //     .then(({ data }) => {
+
+  //       if(data.err) {
+  //         return Alert.error({title: 'Error', message: data.err})
+  //             .then( (result) => result.isConfirmed && navigate(-1) )
+  //       }
+  //       setActivity(data);
+  //     })
+  // }, [])
+  
+  // It shows the loader meanwhile the request is performed
+  if(!activity) return <Loader className='d-flex justify-content-center align-items-center vh-100'/>
+
+  return (
+    <div className='activity-detail'>
+      <div className='activity-image-container'>
+      <img 
+        src={ activity.image } 
+        alt="activity"
+        className='activity-image'
+        />
+      </div>
+
+      <div className='activity-text-container'>
+        <h1 className='activity-text-title'>{ activity.name }</h1>
+        <hr></hr>
+        <p className='activity-text-paragraph'>
+          {activity.content}
+        </p>
+        <button 
+          // onClick={ () => navigate(-1) }
+          className='btn btn-primary text-white px-5 fs-3'
+          style ={{ borderRadius:"6px" }}
+        >
+          Volver
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default ActivityDetailPage

--- a/src/services/AlertService.js
+++ b/src/services/AlertService.js
@@ -28,7 +28,7 @@ export default class Alert {
     }
     
     static error({title,message}){
-        Swal.fire({
+        return Swal.fire({
             title,
             text:message,
             confirmButtonColor: this.buttonConfirmColor,

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -17,6 +17,7 @@
 @import './componentes/textInput';
 
 @import './pages/contact/contactPage';
+@import './pages/activityDetail/activityDetailPage';
 
 @import './components/AlertStyles.scss'
 

--- a/src/styles/pages/activityDetail/_activityDetailPage.scss
+++ b/src/styles/pages/activityDetail/_activityDetailPage.scss
@@ -1,0 +1,50 @@
+.activity-detail{
+  height: 100vh;
+
+  @include responsive($medium){
+    padding-top: 4rem;
+    clear: both;
+  }
+
+  @include responsive($large){
+    max-width: 110rem;
+    margin: 0 auto;
+  }
+}
+
+.activity-image-container{
+  margin-bottom: 1rem;
+
+  @include responsive($small){
+    margin: 0 auto;
+    width: 57.5rem;
+  }
+
+  @include responsive($medium){
+    margin: 0 auto;
+    width: 70rem;
+  }
+
+}
+
+.activity-image{
+  max-width: 100%;
+  min-height: 18rem;
+}
+
+.activity-text-container{
+  padding: 2.5rem;
+}
+
+.activity-text-title{
+  font-size: 2.4rem;
+
+  @include responsive($large){
+    font-size: 2.9rem;
+  }
+}
+
+.activity-text-paragraph{
+  font-size: 1.3rem;
+  margin-bottom: 3rem;
+}


### PR DESCRIPTION

![git](https://user-images.githubusercontent.com/74872179/177019902-015231af-393e-4e5e-883d-336cb58dd160.gif)
<img width="1440" alt="Captura de Pantalla 2022-07-02 a la(s) 7 12 51 p m" src="https://user-images.githubusercontent.com/74872179/177019915-be5bb4f4-dc93-4879-987e-33156bd3e44e.png">

https://alkemy-labs.atlassian.net/browse/OT221-68

**Overview:**

- Added responsive activity detail page component
- Comunication with test endpoint performed including rendering of data. Until the actual endoint is implemented, this code has been disabled via comments. Fake data is provided meanwhile.
- Alert error message is shown if the activity doesn't exist in the DB. When the user confirms the alert pop-up, the component navigates to the previous page. To do this, an alert method has been modified to be able to return the sweet.fire promise to use it to wait for user confirmation and perform the action.